### PR TITLE
Create a symlink to the lastest downloaded executable

### DIFF
--- a/build_loader.py
+++ b/build_loader.py
@@ -134,6 +134,10 @@ class BuildLoader(QThread):
         target_path = Path(os.path.join(self.root_folder, nice_name))
         source_path.rename(target_path)
 
+        # Link to permanent environment variable
+        symlink_path = Path(os.path.join(self.root_folder, "blender.exe"))
+        os.symlink(target_path / "blender.exe", symlink_path)
+
         # Register .blend extension
         if self.parent.settings.value('is_register_blend', type=bool):
             if self.platform == 'Windows':

--- a/build_loader.py
+++ b/build_loader.py
@@ -136,7 +136,8 @@ class BuildLoader(QThread):
 
         # Link to permanent environment variable
         symlink_path = Path(os.path.join(self.root_folder, "blender.exe"))
-        os.symlink(target_path / "blender.exe", symlink_path)
+        symlink_path.unlink(missing_ok=True)
+        symlink_path.symlink_to(target_path / "blender.exe")
 
         # Register .blend extension
         if self.parent.settings.value('is_register_blend', type=bool):


### PR DESCRIPTION
This is a patch for #25.

I guess the whole `.blend`-file default handler thing could be refactored to use this, but I haven't actually tried to understand that code / what you'd have to do to achieve that yet.